### PR TITLE
Update top and Wrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,11 @@ export LD_LIBRARY_PATH := /home/shay/a/ece270/lib:$(LD_LIBRARY_PATH)
 # Specify the name of the top level file (do not include the source folder in the name)
 # NOTE: YOU WILL NEED TO SET THIS VARIABLE'S VALUE WHEN WORKING WITH HEIRARCHICAL DESIGNS
 
-TOP_FILE         := clkdiv.sv
+TOP_FILE         := top.sv
 
 # List internal component/block files here (separate the filenames with spaces)
 # NOTE: YOU WILL NEED TO SET THIS VARIABLE'S VALUE WHEN WORKING WITH HEIRARCHICAL DESIGNS
-COMPONENT_FILES  := 
+COMPONENT_FILES  := clkdiv.sv frequency_divider.sv fsm.sv keypad.sv oscillator.sv PWM.sv signal_mixer.sv smpl_rate_clkdiv.sv waveshaper.sv
 
 # Specify the filepath of the test bench you want to use (ie. tb_top_level.sv)
 # (do not include the source folder in the name)

--- a/source/TMNT.sv
+++ b/source/TMNT.sv
@@ -1,6 +1,6 @@
 `default_nettype none
 
-module insert_project_name_here (
+module TMNT (
     // HW
     input logic clk, nrst,
     

--- a/source/fsm.sv
+++ b/source/fsm.sv
@@ -9,17 +9,22 @@ module fsm(
     );
     //internal signals
     logic [1:0]next_mode;
-    always_ff @( posedge modekey, negedge n_rst ) begin : blockName
+
+    //flip flop
+    always_ff @( posedge clk, negedge n_rst ) begin : fsm_ff
         if (~n_rst) 
         mode <= 0;
     else 
         mode <= next_mode;
     end
-    always_comb begin : blockNamed
+
+    //next state logic
+    always_comb begin : next_state_logic
       case (mode)
-        2'b00: next_mode = 2'b01;
-        2'b01: next_mode = 2'b10;
-        2'b10: next_mode = 2'b11;
+        2'b00: next_mode = modekey ? 2'b01 : 2'b00;
+        2'b01: next_mode = modekey ? 2'b10 : 2'b01;
+        2'b10: next_mode = modekey ? 2'b11 : 2'b10;
+        2'b11: next_mode = modekey ? 2'b00 : 2'b11;
         default: next_mode = 2'b00;
       endcase   
     end

--- a/source/insert_project_name_here.sv
+++ b/source/insert_project_name_here.sv
@@ -9,6 +9,19 @@ module insert_project_name_here (
     inout logic [33:0] gpio // Breakout Board Pins
 );
 
+    logic outsignal; // Output Signal
+    logic n_rst;    // Reset Signal
+    //select logic
+    assign n_rst = cs ? nrst : 1'b0; // Assign the reset signal to the breakout board pin
+
+    // Instantiate the top level module
+    top top_inst (
+        .hwclk(clk),
+        .reset(n_rst),
+        .pb(gpio[20:0]),
+        .sigout(outsignal),
+    );
+
 
 
 endmodule

--- a/source/signal_mixer.sv
+++ b/source/signal_mixer.sv
@@ -24,6 +24,7 @@ module signal_mixer(
     logic [8:0] accumulator;          // 8-bit accumulator for each sample
     logic [7:0] samples [11:0];            // 12 samples 8-bit input
 
+
     //assign the samples to the internal signals
     assign samples[0] = sample_enable[0] ? sample1 : 0;
     assign samples[1] = sample_enable[1] ? sample2 : 0;
@@ -42,10 +43,12 @@ module signal_mixer(
     assign accumulator = samples[0] + samples[1] + samples[2] + samples[3] + samples[4] + samples[5] + samples[6] + samples[7] + samples[8] + samples[9] + samples[10] + samples[11];
 
     // Assign the output as the sum of all the enabled samples
-    always_comb 
-        if (accumulator > 255)
+    always_comb begin
+        if (accumulator >= 255)
             sample_out = 255;
         else
-            sample_out = accumulator[7:0];
+            sample_out = accumulator;
+    end
+
 
 endmodule

--- a/source/smpl_rate_clkdiv.sv
+++ b/source/smpl_rate_clkdiv.sv
@@ -1,6 +1,7 @@
 `default_nettype none
 
 
+
 module sample_rate_clkdiv(
     //inputs
     input logic clk,                   // clock
@@ -10,56 +11,15 @@ module sample_rate_clkdiv(
     );
 
 //internal signals
-    clkDiv #(
+    clkdiv #(
         .BITLEN(8)
     ) clkDiv_inst (
         .clk(clk),
         .n_rst(n_rst),
-        .lim(255),
+        .lim(8'd255),
         .hzX(sample_now),
         .cnt_out()
     ); 
 
 endmodule
-////////supporting modules below///////
 
-module clkDiv#(
-    parameter BITLEN = 8
-    ) (
-    input logic clk,                    // clock
-    input logic n_rst,                    // active high reset 
-    input logic [BITLEN-1:0] lim,       // limit for counter
-    output logic hzX,                   // output clock
-    output logic [BITLEN-1:0] cnt_out   // counter
-    );
-
-    logic [BITLEN-1:0] cnt;
-    logic [BITLEN-1:0] next_cnt;
-    logic next_hzX;
-
-    //flip flop
-    always_ff @ (posedge clk, negedge n_rst) begin
-        if (!n_rst) begin
-            cnt <= 0;
-            hzX <= 0;
-        end
-        else
-            cnt <= next_cnt;
-            hzX <= next_hzX;
-    end
-
-    //combinational logic
-    always_comb begin
-        if (cnt == lim) begin
-            next_cnt = 0;
-            next_hzX = 1;
-        end
-        else begin
-            next_cnt = cnt + 1;
-            next_hzX = 0;
-        end
-    end
-
-            
-
-endmodule

--- a/source/top.sv
+++ b/source/top.sv
@@ -8,6 +8,7 @@ module top
   output logic [7:0] left, right,
          ss7, ss6, ss5, ss4, ss3, ss2, ss1, ss0,
   output logic red, green, blue,
+  output logic sigout,
 
   // UART ports
   output logic [7:0] txdata,
@@ -17,8 +18,12 @@ module top
 );
 
 //inter signal
-logic modekey;              //modekey signal  to be used for mode change
 logic clk;                  // dummy clock used to set 12M to 10M
+logic modekey;              //modekey signal  to be used for mode change
+logic octave_up, octave_down; //octave up and down signals
+logic [11:0] done;          //done signals from wave shaper
+logic [1:0] mode;           //mode signal
+logic [15:0] freq_div_table [0:11]; //frequency division table
 logic [15:0] Count [11:0];  //counters for wave shaper from oscillator
 logic [7:0] samples [11:0]; //samples from wave shaper to signal mixer
 logic [11:0] sample_enable; //sample enable for signal mixer
@@ -28,27 +33,34 @@ logic pwm, pwm_out;         //pwm output
 
 //keypad for modekey
 keypad modein(
-  .clk(clk),
-  .n_rst(reset),
-  .in(pb[15]),
-  .modekey(modekey)
+    .clk(clk),
+    .n_rst(reset),
+    .mode_in(pb[15]),
+    .octive_in({pb[14], pb[13]}),
+    .modekey(modekey),
+    .octive_up(octave_up),
+    .octive_down(octave_down)
 );
 
 //freq divider table
-logic [15:0] freq_div_table [11:0]= {
-  16'd38223, //C
-  16'd36077, //C#
-  16'd34052, //D
-  16'd32141, //D#
-  16'd30337, //E
-  16'd28635, //F
-  16'd27027, //F#
-  16'd25511, //G
-  16'd24079, //G#
-  16'd22727, //A
-  16'd21452, //A#
-  16'd20248  //B
-};
+frequency_divider freq_div(
+    .clk(clk),
+    .nrst(reset),
+    .o_up(octave_up),
+    .o_down(octave_down),
+    .div0(freq_div_table[0]),
+    .div1(freq_div_table[1]),
+    .div2(freq_div_table[2]),
+    .div3(freq_div_table[3]),
+    .div4(freq_div_table[4]),
+    .div5(freq_div_table[5]),
+    .div6(freq_div_table[6]),
+    .div7(freq_div_table[7]),
+    .div8(freq_div_table[8]),
+    .div9(freq_div_table[9]),
+    .div10(freq_div_table[10]),
+    .div11(freq_div_table[11])
+);
 
 
 //sample rate clk div
@@ -62,11 +74,59 @@ sample_rate_clkdiv sample_rate_clkdiv(
 oscillator osc(
   .clk(clk),
   .n_rst(reset),
-  .freq_div_table(freq_div_table),
-  .counts(Count)
+  //freq div table
+  .freq_C(freq_div_table[0]),
+    .freq_Cs(freq_div_table[1]),
+    .freq_D(freq_div_table[2]),
+    .freq_Ds(freq_div_table[3]),
+    .freq_E(freq_div_table[4]),
+    .freq_F(freq_div_table[5]),
+    .freq_Fs(freq_div_table[6]),
+    .freq_G(freq_div_table[7]),
+    .freq_Gs(freq_div_table[8]),
+    .freq_A(freq_div_table[9]),
+    .freq_As(freq_div_table[10]),
+    .freq_B(freq_div_table[11]),
+    //counters
+  .count_out_C(Count[0]),
+    .count_out_Cs(Count[1]),
+    .count_out_D(Count[2]),
+    .count_out_Ds(Count[3]),
+    .count_out_E(Count[4]),
+    .count_out_F(Count[5]),
+    .count_out_Fs(Count[6]),
+    .count_out_G(Count[7]),
+    .count_out_Gs(Count[8]),
+    .count_out_A(Count[9]),
+    .count_out_As(Count[10]),
+    .count_out_B(Count[11])
+);
+
+
+//FSM
+fsm FSM(
+    .clk(clk),
+    .n_rst(reset),
+    .modekey(modekey),
+    .mode(mode)
 );
 
 //waveshapers
+generate
+    genvar i;
+        for (i = 0; i < 12; i = i + 1) begin
+            waveshaper wave_shpr(
+                .clk(clk),
+                .nrst(reset),
+                .fd(freq_div_table[i]),
+                .count(Count[i]),
+                .mode(mode),
+                .start(start),
+                .signal(samples[i]),
+                .done(done[i])
+            );
+        end
+endgenerate
 
 
 //signal mixer
@@ -91,7 +151,7 @@ signal_mixer mixer(
 pwm PWM(
   .clk(clk),
   .n_rst(reset),
-  .start(start),
+  .start(|done),
   .final_in(final_sample),
   .pwm_out(pwm)
 );
@@ -101,223 +161,4 @@ always_ff @(posedge clk)
   pwm_out <= pwm;
 
 
-endmodule
-
-/////////////////////////////////////////
-///////     Extra Modules Here  /////////
-/////////////////////////////////////////
-
-
-////////////////Keypad Module/////////////
-
-module keypad(
-    //inputs
-    input logic clk,        //clock
-    input logic n_rst,      // active low reset  
-    input logic in,         //input signal pb[15]
-    output logic modekey    //output signal modekey
-  );
-
-  //internal signals
-  logic [1:0] delay;
-
-  always_ff @( posedge clk, posedge n_rst ) begin : blockName
-      if (n_rst) 
-          delay <= {delay[0], in};
-      else 
-          delay <= 2'b00;
-  end
-
-  //posedge detection
-  assign modekey = delay[0] & ~delay[1];
-
-endmodule
-
-/////  Sample Rate Divider Module  ///////
-module sample_rate_clkdiv(
-    //inputs
-    input logic clk,                   // clock
-    input logic n_rst,                 // active high reset
-    //outputs
-    output logic sample_now            // sample now
-    );
-
-    //internal signals
-    clkdiv #(
-        .BITLEN(8)
-    ) clkdiv_inst (
-        .clk(clk),
-        .n_rst(n_rst),
-        .lim(255),
-        .hzX(sample_now),
-        .cnt_out()
-    ); 
-
-endmodule
-
-
-/////////// Oscillator Module ////////////
-module oscillator (
-    input logic clk,                    // clock input
-    input logic n_rst,                  // reset input active low
-    input [15:0] freq_div_table [0:11], // frequency division table
-    output [15:0] counts [0:11]         // output counts
-    );
-
-    generate
-        genvar i;
-        for (i = 0; i < 12; i++) begin
-            clkdiv #(.BITLEN(16)) clkdiv_inst (
-                .clk(clk),
-                .n_rst(n_rst),
-                .lim(freq_div_table[i]),
-                .hzX(),
-                .cnt_out(counts[i])
-            );
-        end
-    endgenerate
-
-
-endmodule
-
-/////////// Wave Shaper Module ///////////
-
-
-/////////// Signal Mixer Module //////////
-module signal_mixer(
-    //inputs
-    input logic [7:0] sample1 ,    
-    input logic [7:0] sample2 ,
-    input logic [7:0] sample3 ,
-    input logic [7:0] sample4 ,
-    input logic [7:0] sample5 ,
-    input logic [7:0] sample6 ,
-    input logic [7:0] sample7 ,
-    input logic [7:0] sample8 ,
-    input logic [7:0] sample9 ,
-    input logic [7:0] sample10 ,
-    input logic [7:0] sample11 ,
-    input logic [7:0] sample12 ,
-                                            // 12 samples 8-bit input
-    input logic [11:0] sample_enable,       //12 samples enable
-    //outputs
-    output logic [7:0] sample_out           //1 sample 8-bit output
-    );
-    
-    //internal signals 
-    logic [8:0] accumulator;          // 8-bit accumulator for each sample
-    logic [7:0] samples [11:0];            // 12 samples 8-bit input
-
-    //assign the samples to the internal signals
-    assign samples[0] = sample_enable[0] ? sample1 : 0;
-    assign samples[1] = sample_enable[1] ? sample2 : 0;
-    assign samples[2] = sample_enable[2] ? sample3 : 0;
-    assign samples[3] = sample_enable[3] ? sample4 : 0;
-    assign samples[4] = sample_enable[4] ? sample5 : 0;
-    assign samples[5] = sample_enable[5] ? sample6 : 0;
-    assign samples[6] = sample_enable[6] ? sample7 : 0;
-    assign samples[7] = sample_enable[7] ? sample8 : 0;
-    assign samples[8] = sample_enable[8] ? sample9 : 0;
-    assign samples[9] = sample_enable[9] ? sample10 : 0;
-    assign samples[10] = sample_enable[10] ? sample11 : 0;
-    assign samples[11] = sample_enable[11] ? sample12 : 0;
-    
-    //sum all the enabled samples
-    assign accumulator = samples[0] + samples[1] + samples[2] + samples[3] + samples[4] + samples[5] + samples[6] + samples[7] + samples[8] + samples[9] + samples[10] + samples[11];
-
-    // Assign the output as the sum of all the enabled samples
-    assign sample_out = accumulator[7:0];
-
-endmodule
-
-/////////// PWM Module ///////////////////
-
-module pwm(
-    //inputs
-    input logic clk,            //clock
-    input logic n_rst,          //active low reset
-    input logic start,          //start signal from wave shaper
-    input logic [7:0] final_in, //final input from signal mixer
-    //outputs
-    output logic pwm_out         //pwm output
-    );
-
-    //internal signals
-    logic [7:0] final_sample_in;     //sample input from signal mixer
-    logic [7:0] counter;            //counter for pwm
-    logic [7:0] next_counter;       //next counter for pwm
-    logic next_pwm_out;             //next pwm output
-
-    //Flip flop for pwm
-    always_ff @(posedge clk, posedge n_rst) begin
-        if (n_rst) begin
-            if (start) begin
-                final_sample_in <= final_in;
-                counter <= next_counter;
-                pwm_out <= next_pwm_out;
-            end
-            else begin
-                final_sample_in <= 8'b0;
-                counter <= 8'b0;
-                pwm_out <= 1'b0;
-            end
-        end
-    end
-
-    //comb logic for pwm
-    always_comb begin
-        //next counter
-        if(counter == 255)
-            next_counter = 8'b0;
-        else
-            next_counter = counter + 1;
-
-        //next pwm output
-        if( counter <= final_sample_in)
-            next_pwm_out = 1'b1;
-        else
-            next_pwm_out = 1'b0;
-    end
-
-endmodule
-
-//////////// Clock Div Module ////////////
-module clkdiv#(
-    parameter BITLEN = 8
-    ) (
-    input logic clk,                    // clock
-    input logic n_rst,                    // active high reset 
-    input logic [BITLEN-1:0] lim,       // limit for counter
-    output logic hzX,                   // output clock
-    output logic [BITLEN-1:0] cnt_out   // counter
-    );
-
-    logic [BITLEN-1:0] cnt;
-    logic [BITLEN-1:0] next_cnt;
-    logic next_hzX;
-
-    //flip flop
-    always_ff @ (posedge clk, negedge n_rst) begin
-        if (!n_rst) begin
-            cnt <= 0;
-            hzX <= 0;
-        end
-        else
-            cnt <= next_cnt;
-            hzX <= next_hzX;
-    end
-
-    //combinational logic
-    always_comb begin
-        if (cnt == lim) begin
-            next_cnt = 0;
-            next_hzX = 1;
-        end
-        else begin
-            next_cnt = cnt + 1;
-            next_hzX = 0;
-        end
-    end
-
-            
 endmodule

--- a/test.txt
+++ b/test.txt
@@ -1,1 +1,0 @@
-this is a permissions test


### PR DESCRIPTION
Changes:
- made FSM next state logic dependent on modekey
- changed clk in FSM to system clk instead of modekey to avoid timing domain issues
- updated top to handle 1D arrays instead of 2Darrays 
- added instances of modules to complete design
- changed top and component files in makefile
- fixed addressing in signal_mixer to avoid an error
- removed clkDiv from sample_rate_clkdiv replaced with clkdiv 

Added:
- TMNT file as wrapper for synth

Removed:
- inset_project_name_here.sv replaced with TMNT
- test.txt

BUGS:
- (@kriegl418 ) waveshaper line 77 gives an error due to addressing assignment in comb block. it is technically a warning, but escalated to error
`always_comb begin
    if (acc >= {1'b0, b1}) begin
      acc_next = acc - b1;
      {acc_next, quo_next} = {acc_next[WIDTH - 1:0], quo, 1'b1};
    end else begin
      {acc_next, quo_next} = {acc, quo} << 1;
    end
  end`

![image](https://github.com/STARS-Design-Track-2023/Teenage-Mixing-Ninja-Turtles/assets/93798166/eaf7edd8-d841-4382-8d60-41f63f6bb3a2)



